### PR TITLE
Clear chart buffer

### DIFF
--- a/mainwindow.cpp
+++ b/mainwindow.cpp
@@ -222,6 +222,7 @@ void MainWindow::clearChart() {
     for (auto &buf : filterBuffers) {
         buf.clear();
     }
+    buffer.clear();
     x = 0;
     axisX->setRange(0, windowSize);
 }


### PR DESCRIPTION
## Summary
- reset the serial input buffer when clearing the chart

## Testing
- `cmake ..` *(fails: could not find Qt6)*
