### PR TITLE
Add Qt unit test for clearChart

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,3 +85,6 @@ install(TARGETS IPNPlotter
 if(QT_VERSION_MAJOR EQUAL 6)
     qt_finalize_executable(IPNPlotter)
 endif()
+
+enable_testing()
+add_subdirectory(tests)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+set(CMAKE_AUTOUIC ON)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+
+find_package(Qt6 REQUIRED COMPONENTS Core Widgets Test SerialPort Charts)
+
+add_executable(test_clearChart
+    test_clearChart.cpp
+    ${PROJECT_SOURCE_DIR}/mainwindow.cpp
+    ${PROJECT_SOURCE_DIR}/mainwindow.h
+    ${PROJECT_SOURCE_DIR}/mainwindow.ui
+)
+
+target_include_directories(test_clearChart PRIVATE ${PROJECT_SOURCE_DIR})
+
+target_link_libraries(test_clearChart
+    PRIVATE Qt6::Core Qt6::Widgets Qt6::Test Qt6::SerialPort Qt6::Charts
+)
+
+add_test(NAME test_clearChart COMMAND test_clearChart)
+set_tests_properties(test_clearChart PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/test_clearChart.cpp
+++ b/tests/test_clearChart.cpp
@@ -1,0 +1,35 @@
+#define private public
+#include "../mainwindow.h"
+#undef private
+#include <QtTest/QtTest>
+
+class TestClearChart : public QObject {
+    Q_OBJECT
+private slots:
+    void clearChartResets();
+};
+
+void TestClearChart::clearChartResets() {
+    MainWindow w;
+    // create a series and attach to chart axes
+    QLineSeries *series = new QLineSeries();
+    w.chart->addSeries(series);
+    series->attachAxis(w.axisX);
+    series->attachAxis(w.axisY);
+    w.seriesList.append(series);
+
+    series->append(0, 1);
+    series->append(1, 2);
+    w.x = 2;
+    w.axisX->setRange(1, 3);
+
+    w.clearChart();
+
+    QCOMPARE(series->count(), 0);
+    QCOMPARE(w.x, 0);
+    QCOMPARE(w.axisX->min(), 0.0);
+    QCOMPARE(w.axisX->max(), double(w.windowSize));
+}
+
+QTEST_MAIN(TestClearChart)
+#include "test_clearChart.moc"


### PR DESCRIPTION
## Summary
- enable CTest and add tests subdirectory
- add Qt Test CMake config
- implement test_clearChart verifying reset behavior

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`