### PR TITLE
Detect channel count from UART

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -45,6 +45,7 @@ private:
     void setupChart();
     void setupSerialControls();
     void updatePortList();
+    void adjustChannelCount(int newCount);
 
     Ui::MainWindow *ui;
 


### PR DESCRIPTION
## Summary
- detect how many values arrive in each serial line
- adjust the channel count dynamically and clear the chart when the amount of channels changes

## Testing
- `cmake ..` *(fails: FindQt6.cmake not found)*
- `ctest --output-on-failure` *(no tests were run)*
