### PR TITLE
Add FFT frequency view

### DIFF
--- a/mainwindow.h
+++ b/mainwindow.h
@@ -18,6 +18,7 @@
 #include <QGroupBox>
 #include <QQueue>
 #include <QList>
+#include <QVector>
 
 QT_BEGIN_NAMESPACE
 namespace Ui { class MainWindow; }
@@ -38,11 +39,13 @@ private slots:
     void updateSerialSettings();
     void refreshPorts();
     void clearChart();
+    void updateFFTView();
 
 
 private:
     void setupUI();
     void setupChart();
+    QVector<double> computeFFT(const QVector<double> &samples);
     void setupSerialControls();
     void updatePortList();
     void adjustChannelCount(int newCount);
@@ -59,6 +62,11 @@ private:
     QChartView *chartView;
     QValueAxis *axisX;
     QValueAxis *axisY;
+    QLineSeries *fftSeries;
+    QChart *fftChart;
+    QChartView *fftChartView;
+    QValueAxis *fftAxisX;
+    QValueAxis *fftAxisY;
 
     enum class FilterType { None, MovingAverage };
     FilterType filterType = FilterType::None;
@@ -70,6 +78,7 @@ private:
     int maxPoints = 1000;
     int windowSize = 1000;
     int channelCount = 0;
+    QVector<double> samplesBuffer;
 
     // UI Controls (accessible from .ui file)
     QComboBox *portComboBox;

--- a/mainwindow.ui
+++ b/mainwindow.ui
@@ -234,10 +234,38 @@
      </widget>
     </item>
     <item>
-     <widget class="QWidget" name="chartWidget" native="true">
-      <property name="styleSheet">
-       <string>QWidget { border: 1px solid #ccc; }</string>
+     <widget class="QTabWidget" name="viewTabWidget">
+      <property name="currentIndex">
+       <number>0</number>
       </property>
+      <widget class="QWidget" name="timeTab">
+       <attribute name="title">
+        <string>Tiempo</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_time">
+        <item>
+         <widget class="QWidget" name="chartWidget" native="true">
+          <property name="styleSheet">
+           <string>QWidget { border: 1px solid #ccc; }</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="freqTab">
+       <attribute name="title">
+        <string>Frecuencia</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayout_freq">
+        <item>
+         <widget class="QWidget" name="fftChartWidget" native="true">
+          <property name="styleSheet">
+           <string>QWidget { border: 1px solid #ccc; }</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </widget>
     </item>
    </layout>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,3 +19,13 @@ target_link_libraries(test_clearChart
 
 add_test(NAME test_clearChart COMMAND test_clearChart)
 set_tests_properties(test_clearChart PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")
+
+add_executable(test_fft
+    test_fft.cpp
+    ${PROJECT_SOURCE_DIR}/mainwindow.cpp
+    ${PROJECT_SOURCE_DIR}/mainwindow.h
+)
+target_include_directories(test_fft PRIVATE ${PROJECT_SOURCE_DIR})
+target_link_libraries(test_fft PRIVATE Qt6::Core Qt6::Widgets Qt6::Test Qt6::SerialPort Qt6::Charts)
+add_test(NAME test_fft COMMAND test_fft)
+set_tests_properties(test_fft PROPERTIES ENVIRONMENT "QT_QPA_PLATFORM=offscreen")

--- a/tests/test_fft.cpp
+++ b/tests/test_fft.cpp
@@ -1,0 +1,33 @@
+#define private public
+#include "../mainwindow.h"
+#undef private
+#include <QtTest/QtTest>
+#include <cmath>
+
+class TestFFT : public QObject {
+    Q_OBJECT
+private slots:
+    void fftDetectsSine();
+};
+
+void TestFFT::fftDetectsSine() {
+    MainWindow w;
+    QVector<double> samples;
+    int N = 8;
+    for (int n = 0; n < N; ++n) {
+        samples.append(std::sin(2 * 3.14159265358979323846 * n / N));
+    }
+    QVector<double> mags = w.computeFFT(samples);
+    int maxIndex = 0;
+    double maxVal = mags[0];
+    for (int i = 1; i < mags.size(); ++i) {
+        if (mags[i] > maxVal) {
+            maxVal = mags[i];
+            maxIndex = i;
+        }
+    }
+    QVERIFY(maxIndex == 1 || maxIndex == N - 1);
+}
+
+QTEST_MAIN(TestFFT)
+#include "test_fft.moc"


### PR DESCRIPTION
## Summary
- introduce a tabbed view for time and frequency domains
- implement basic FFT computation and frequency chart
- keep a buffer of recent samples and update the FFT view on new data
- add unit test for the FFT routine

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*
